### PR TITLE
Refactor HatForm and SockForm to take individual props instead of state object

### DIFF
--- a/src/HatComponents/HatForm.jsx
+++ b/src/HatComponents/HatForm.jsx
@@ -21,7 +21,8 @@ function HatForm(props) {
                     name='stsPerInch' 
                     step='0.25' 
                     onChange={props.onChange}
-                    state={props.state}
+                    value={props.stsPerInch}
+                    submitted={props.submitted}
                 />
 
                 <NumberInput 
@@ -29,7 +30,8 @@ function HatForm(props) {
                     name='rowsPerInch' 
                     step='0.25' 
                     onChange={props.onChange} 
-                    state={props.state}
+                    value={props.rowsPerInch}
+                    submitted={props.submitted}
                 />
 
                 <div className="form-group">
@@ -37,7 +39,7 @@ function HatForm(props) {
                     <select id="height"
                         className="form-control"
                         name="height"
-                        value={props.state.height}
+                        value={props.height}
                         onChange={props.onChange}>
                         <option value="5.75">0-6 mo</option>
                         <option value="6.5">6-12 mo</option>
@@ -50,11 +52,12 @@ function HatForm(props) {
                 </div>
 
                 <NumberInput 
-                    label={`Circumference of head in inches (common numbers for your size: ${circsByHeight[props.state.height]}): `}
+                    label={`Circumference of head in inches (common numbers for your size: ${circsByHeight[props.height]}): `}
                     name='circumference' 
                     step='0.125' 
                     onChange={props.onChange} 
-                    state={props.state}
+                    value={props.circumference}
+                    submitted={props.submitted}
                 />
                     
 
@@ -63,7 +66,7 @@ function HatForm(props) {
                     <select id="fittedOrSlouchy"
                         className="form-control"
                         name="fittedOrSlouchy"
-                        value={props.state.fittedOrSlouchy}
+                        value={props.fittedOrSlouchy}
                         onChange={props.onChange}>
                         <option value="fitted">Fitted</option>
                         <option value="slouchy">Slouchy</option>
@@ -72,7 +75,7 @@ function HatForm(props) {
             </fieldset>
 
             <div>
-                <input className="btn btn-info" type="submit" value={props.state.buttonText} />
+                <input className="btn btn-info" type="submit" value={props.buttonText} />
             </div>
         </form>
     );

--- a/src/HatComponents/HatGenerator.jsx
+++ b/src/HatComponents/HatGenerator.jsx
@@ -89,7 +89,13 @@ function HatGenerator() {
           <HatForm
             onChange={handleChange}
             onSubmit={handleSubmit}
-            state={{ stsPerInch, rowsPerInch, circumference, height, fittedOrSlouchy, buttonText, submitted, valid, fullStCount, toTopButton }}
+            stsPerInch={stsPerInch}
+            rowsPerInch={rowsPerInch}
+            circumference={circumference}
+            height={height}
+            fittedOrSlouchy={fittedOrSlouchy}
+            buttonText={buttonText}
+            submitted={submitted}
           />
 
           {valid && (

--- a/src/NumberInput.jsx
+++ b/src/NumberInput.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
 function NumberInput(props) {
-    const invalid = Boolean(props.submitted) && Number(props.value) <= 0;
+    const value =
+        props.value !== undefined ? props.value : props.state?.[props.name];
+    const submitted =
+        props.submitted !== undefined ? props.submitted : props.state?.submitted;
+    const invalid = Boolean(submitted) && Number(value) <= 0;
     return (
         <div className="form-group">
             <label htmlFor={props.name}>{props.label}</label>
@@ -10,7 +14,7 @@ function NumberInput(props) {
                 type="number" 
                 min="0" 
                 step={props.step} 
-                placeholder={props.value}
+                placeholder={value}
                 name={props.name}
                 onChange={props.onChange} />
                 {/* Show error message if form has been submitted but number is not greater than 0 */}

--- a/src/NumberInput.jsx
+++ b/src/NumberInput.jsx
@@ -1,19 +1,20 @@
 import React from 'react';
 
 function NumberInput(props) {
+    const invalid = Boolean(props.submitted) && Number(props.value) <= 0;
     return (
         <div className="form-group">
             <label htmlFor={props.name}>{props.label}</label>
             <input id={props.name} 
-                className={`form-control ${ (props.state.submitted && props.state[props.name] <= 0) && 'is-invalid'}`}
+                className={`form-control ${invalid && 'is-invalid'}`}
                 type="number" 
                 min="0" 
                 step={props.step} 
-                placeholder={props.state[props.name]}
+                placeholder={props.value}
                 name={props.name}
                 onChange={props.onChange} />
                 {/* Show error message if form has been submitted but number is not greater than 0 */}
-                { (props.state.submitted && props.state[props.name] <= 0) && 
+                { invalid && 
                     <span className="error invalid-feedback">Please enter a number greater than 0</span> }
         </div>
     );

--- a/src/SockComponents/SockForm.jsx
+++ b/src/SockComponents/SockForm.jsx
@@ -13,7 +13,8 @@ function SockForm(props) {
                             name='stsPerInch' 
                             step='0.25' 
                             onChange={props.onChange}
-                            state={props.state}
+                            value={props.stsPerInch}
+                            submitted={props.submitted}
                         />
 
                         <NumberInput 
@@ -21,7 +22,8 @@ function SockForm(props) {
                             name='circumference' 
                             step='0.125' 
                             onChange={props.onChange} 
-                            state={props.state}
+                            value={props.circumference}
+                            submitted={props.submitted}
                         />
 
                         <NumberInput 
@@ -29,7 +31,8 @@ function SockForm(props) {
                             name='footLength' 
                             step='0.125' 
                             onChange={props.onChange} 
-                            state={props.state}
+                            value={props.footLength}
+                            submitted={props.submitted}
                         />
                     </fieldset>
                 </div>
@@ -45,7 +48,7 @@ function SockForm(props) {
                                 value="toeup"
                                 onChange={props.onChange} 
                                 required 
-                                checked={props.state.direction === 'toeup'} />
+                                checked={props.direction === 'toeup'} />
                             <label className="form-check-label" htmlFor="toeup">Toe Up</label>
                         </div>
 
@@ -58,15 +61,15 @@ function SockForm(props) {
                                 value="cuffdown" 
                                 onChange={props.onChange}
                                 required 
-                                checked={props.state.direction === 'cuffdown'} />
+                                checked={props.direction === 'cuffdown'} />
                             <label className="form-check-label" htmlFor="cuffdown">Cuff Down</label>
                         </div>
                         {/* show short row heel message if direction is toe up */}
-                        {props.state.direction === 'toeup' && 
+                        {props.direction === 'toeup' && 
                             <p id="toe-up-short-row">Your toe-up sock recipe will include a short-row heel.</p> }
                     </fieldset>
                     {/* only show heel choices if direction is cuff down */}
-                    { props.state.direction === 'cuffdown' && 
+                    { props.direction === 'cuffdown' && 
                     <fieldset id="heel-type" className="form-group">
                         <legend>Heel Type<br /><span>What kind of heel do you want to use?</span></legend>
                         <div className="form-check form-check-inline">
@@ -78,7 +81,7 @@ function SockForm(props) {
                                 value="flap" 
                                 onChange={props.onChange}
                                 required 
-                                checked={props.state.heeltype === 'flap'} />
+                                checked={props.heeltype === 'flap'} />
                             <label className="form-check-label" htmlFor="flap">Heel flap with gusset</label>
                         </div>
                 
@@ -91,14 +94,14 @@ function SockForm(props) {
                                 value="shortrow" 
                                 onChange={props.onChange}
                                 required 
-                                checked={props.state.heeltype === 'shortrow'} />
+                                checked={props.heeltype === 'shortrow'} />
                             <label className="form-check-label" htmlFor="shortrow">Short row heel</label>
                         </div>
 
                     </fieldset> }
 
                     <div>
-                        <input className="btn btn-info" type="submit" value={props.state.buttonText} />
+                        <input className="btn btn-info" type="submit" value={props.buttonText} />
                     </div>
                 </div>
             </div>

--- a/src/SockComponents/SockGenerator.jsx
+++ b/src/SockComponents/SockGenerator.jsx
@@ -90,7 +90,13 @@ function SockGenerator() {
           <SockForm
             onChange={handleChange}
             onSubmit={handleSubmit}
-            state={{ stsPerInch, circumference, footLength, direction, heeltype, buttonText, submitted, valid, fullStCount, toTopButton }}
+            stsPerInch={stsPerInch}
+            circumference={circumference}
+            footLength={footLength}
+            direction={direction}
+            heeltype={heeltype}
+            buttonText={buttonText}
+            submitted={submitted}
           />
 
           {valid && (


### PR DESCRIPTION
Pass values and submitted flag explicitly from HatGenerator; update NumberInput to use value and submitted for validation styling.

Made-with: Cursor